### PR TITLE
Deploy startmc.sh to VPS via GitHub Actions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,32 @@
+name: Deployment
+
+# Controls when the action will run.
+on:
+  # Triggers the workflow on push or pull request events but only for the master branch
+  push:
+    branches: [ master ]
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      - name: Deploy using ssh
+        uses: appleboy/ssh-action@master
+        with:
+          host: ${{ secrets.SSH_HOST }}
+          username: ${{ secrets.SSH_USER }}
+          key: ${{ secrets.SSH_PRIVATE_KEY }}
+          port: 22
+          script: |
+            cd ~/startmc.sh
+            git pull origin master
+            git status
+            export NVM_DIR="$HOME/.nvm"
+            [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
+            npm install
+            npm run build

--- a/ecosystem.config.js
+++ b/ecosystem.config.js
@@ -1,0 +1,9 @@
+module.exports = {
+    script: "serve",
+    env: {
+        PM2_SERVE_PATH: './dist',
+        PM2_SERVE_PORT: 3001,
+        PM2_SERVE_SPA: 'true',
+        PM2_SERVE_HOMEPAGE: './dist/index.html'
+    }
+}


### PR DESCRIPTION
This PR deploys startmc.sh to my VPS, rather than GitHub Pages.