### PR TITLE
Remove space in wrong place and make script dash-compliant

### DIFF
--- a/src/lib/scripts.js
+++ b/src/lib/scripts.js
@@ -44,8 +44,8 @@ FLAGS="@flags@"
 
 while [ true ]; do
     echo "Starting server..."
-    \${JAVA} -Xmx\$ {RAM} -Xms\${RAM} \${FLAGS} -jar \${JAR}  --nogui
-    for i in {3..1}; do
+    \${JAVA} -Xmx\${RAM} -Xms\${RAM} \${FLAGS} -jar \${JAR}  --nogui
+    for i in 3 2 1; do
         printf 'Server restarting in %s... (press CTRL-C to exit)\\n' "\${i}"
         sleep 1
     done


### PR DESCRIPTION
Poor folks might run the script as `sh start.sh` instead of first giving it executable mode and running script directly (so that it'll use the bash shell mentioned in shebang).