### PR TITLE
add function to automatically apply 12GB+ flags

### DIFF
--- a/src/lib/Script/index.svelte
+++ b/src/lib/Script/index.svelte
@@ -32,11 +32,24 @@
     //
     // $: scriptText = `${javaPath} -jar ${filename} -Xmx${ram} -Xms${ram} ${flagText} --nogui`
 
+    //function to automatically apply 12gb+ flags
+    function autoAikar12GB(ram) {
+            if (ram != null) {
+                ram = ram.replace("M", "");
+                if (ram >=12000) {
+                    ram = ram+"m";
+                    return`${Object.keys(scripts.flags["aikar12gb"].template).join(' ')}`
+                }
+            }
+            return `${Object.keys(scripts.flags["aikar"].template).join(' ')}`
+        }
+
     $: scriptText = scripts.types[scriptType].template
         .replace("@java@", javaPath)
         .replace("@filename@", filename)
         .replace("@ram@", ram)
-        .replace("@flags@", flagText)
+        .replace("@flags@", autoAikar12GB(ram))
+
 </script>
 
 <svelte:head>


### PR DESCRIPTION
This pr adds a function to automatically apply flags suited for RAM commitment over 12GB. I think the site should notify of this, but I'm not too familiar with V2's codebase/Svelte as of yet.